### PR TITLE
Fix to work with Firefox.

### DIFF
--- a/server/public/js/index.js
+++ b/server/public/js/index.js
@@ -113,18 +113,14 @@ window.addEventListener('load', function() {
 
   // image preview
   document.getElementById("foo").addEventListener("change", imagePreview);
-  function imagePreview(event) {
-    console.log(event);
-    let input = event.srcElement;
-    console.log(input.files);
-    console.log(input.files[0]);
+  function imagePreview() {
+    let input = document.querySelector('input[type=file]');
     if (input.files && input.files[0]) {
       let fileReader = new FileReader();
-
-      fileReader.onload = function (e) {
+      fileReader.onload = function () {
         const imagePreview = document.getElementById('imagePreview');
-        imagePreview.src = e.target.result;
-        imagePreview.style = "";
+        imagePreview.src = fileReader.result;
+        imagePreview.style = "display: block;";
       };
 
       fileReader.readAsDataURL(input.files[0]);


### PR DESCRIPTION
The Javascript for ImagePreview() didn't show the picture when
running in Firefox. This fix is from watson-vehicle-damage-analyzer
commit ce4bf1b24476 .